### PR TITLE
Added internal support for the Content-Length HTTP Header

### DIFF
--- a/src/http/headers.rs
+++ b/src/http/headers.rs
@@ -54,6 +54,17 @@ impl HttpHeaders {
         self.data.insert(key, value);
     }
 
+    /// Retrieves the value of a header by its key.
+    ///
+    /// # Parameters
+    /// * `key` - The header field name to look up
+    ///
+    /// # Returns
+    /// An Option containing a reference to the header value if it exists
+    pub fn get(&self, key: &str) -> Option<&String> {
+        self.data.get(key)
+    }
+
     /// Sets the Host header.
     pub fn set_host(&mut self, host: String) {
         self.insert("Host".to_string(), host);

--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -82,6 +82,13 @@ impl HttpResponse {
             headers.insert(key.to_string(), value.to_string());
         }
 
+        // Check for a Content-Length header to set the total bytes to read
+        if let Some(content_length) = headers.get("Content-Length") {
+            if let Ok(content_length) = content_length.parse::<usize>() {
+                buffer.set_total_bytes(content_length);
+            }
+        }
+
         Ok(HttpResponse {
             status,
             headers,

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,12 @@ pub fn main() {
     let request = client.request(HttpMethod::GET, "http://httpbin.org/anything");
     let mut response = client.send(&request).unwrap();
     println!("Status: {}", response.status);
+
+    println!("Headers:");
+    for (key, value) in response.headers.iter() {
+        println!("{}: {}", key, value);
+    }
+
     let body = response.body_as_string().unwrap();
     println!("Body: {}", body);
 


### PR DESCRIPTION
Added internal support for the Content-Length HTTP Header. Previously we were waiting for the server to close the connection before we would be considered "done" with reading. This was resulting in seemingly long processing times. Now, if the Content-Length header is set, we will stop reading once we have finished reading the required bytes.